### PR TITLE
wallets/generate: generate in stable order

### DIFF
--- a/cmd/storjscan/main.go
+++ b/cmd/storjscan/main.go
@@ -232,8 +232,8 @@ func generate(cmd *cobra.Command, args []string) (err error) {
 		return errs.Wrap(err)
 	}
 
-	for addr, info := range addresses {
-		err = w.Write([]string{addr.String(), info})
+	for _, addr := range addresses {
+		err = w.Write([]string{addr.Address.String(), addr.Info})
 		if err != nil {
 			return errs.Wrap(err)
 		}

--- a/cmd/storjscan/main_test.go
+++ b/cmd/storjscan/main_test.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 
@@ -50,14 +49,9 @@ func TestImport(t *testing.T) {
 		addresses, err := wallets.Generate(ctx, "defaultkey", 0, 5, mnemonic)
 		require.NoError(t, err)
 
-		addressesSlice := []common.Address{}
-		for address := range addresses {
-			addressesSlice = append(addressesSlice, address)
-		}
-
 		// sort descending
-		sort.Slice(addressesSlice, func(i, j int) bool {
-			return bytes.Compare(addressesSlice[i].Bytes(), addressesSlice[j].Bytes()) > 0
+		sort.Slice(addresses, func(i, j int) bool {
+			return bytes.Compare(addresses[i].Address.Bytes(), addresses[j].Address.Bytes()) > 0
 		})
 
 		importFilePath := ctx.File("wallets.csv")
@@ -65,9 +59,8 @@ func TestImport(t *testing.T) {
 		require.NoError(t, err)
 
 		fmt.Fprintln(importFile, "address,info")
-		for _, address := range addressesSlice {
-			info := addresses[address]
-			fmt.Fprintf(importFile, "%s,%s\n", address.String(), info)
+		for _, address := range addresses {
+			fmt.Fprintf(importFile, "%s,%s\n", address.Address.String(), address.Info)
 		}
 		require.NoError(t, importFile.Close())
 
@@ -77,7 +70,7 @@ func TestImport(t *testing.T) {
 		require.NoErrorf(t, err, "Error running test: %s", out)
 
 		// verify that addresses are claimed in the import order
-		for _, expectedAddress := range addressesSlice {
+		for _, expectedAddress := range addresses {
 			address, err := service.Claim(ctx, "eu1")
 			require.NoError(t, err)
 

--- a/wallets/generate.go
+++ b/wallets/generate.go
@@ -48,9 +48,14 @@ func derive(masterKey *hdkeychain.ExtendedKey, path accounts.DerivationPath) (ac
 	}, nil
 }
 
+type GeneratedAddress struct {
+	Address common.Address
+	Info    string
+}
+
 // Generate creates new HD wallet addresses.
-func Generate(ctx context.Context, keysname string, min, max int, mnemonic string) (map[common.Address]string, error) {
-	addr := make(map[common.Address]string)
+func Generate(ctx context.Context, keysname string, min, max int, mnemonic string) ([]GeneratedAddress, error) {
+	addrs := make([]GeneratedAddress, 0, max-min)
 
 	if mnemonic == "" {
 		return nil, errs.New("mnemonic is required")
@@ -80,7 +85,10 @@ func Generate(ctx context.Context, keysname string, min, max int, mnemonic strin
 		if err != nil {
 			return nil, err
 		}
-		addr[account.Address] = keysname + " " + path.String()
+		addrs = append(addrs, GeneratedAddress{
+			Address: account.Address,
+			Info:    keysname + " " + path.String(),
+		})
 	}
-	return addr, nil
+	return addrs, nil
 }

--- a/wallets/generate_test.go
+++ b/wallets/generate_test.go
@@ -52,10 +52,10 @@ func TestGenerate(t *testing.T) {
 		client1 := wallets.NewClient("http://"+lis.Addr().String(), "eu1", "secret")
 
 		var inserts1 []wallets.InsertWallet
-		for address, info := range addresses1 {
+		for _, address := range addresses1 {
 			inserts1 = append(inserts1, wallets.InsertWallet{
-				Address: address,
-				Info:    info,
+				Address: address.Address,
+				Info:    address.Info,
 			})
 		}
 		err = client1.AddWallets(ctx, inserts1)
@@ -66,10 +66,10 @@ func TestGenerate(t *testing.T) {
 		client2 := wallets.NewClient("http://"+lis.Addr().String(), "eu1", "secret")
 
 		var inserts2 []wallets.InsertWallet
-		for address, info := range addresses2 {
+		for _, address := range addresses2 {
 			inserts2 = append(inserts2, wallets.InsertWallet{
-				Address: address,
-				Info:    info,
+				Address: address.Address,
+				Info:    address.Info,
 			})
 		}
 		err = client2.AddWallets(ctx, inserts2)


### PR DESCRIPTION
maps don't have a defined order. this change keeps the generated addresses in order of creation.