### PR TITLE
tools/sweeper: add --filter-file flag to load wallet filter from file

### DIFF
--- a/tools/sweeper/cmd/sweeper/main.go
+++ b/tools/sweeper/cmd/sweeper/main.go
@@ -25,6 +25,7 @@ func main() {
 	zkTokensFlag := flag.String("zksync-tokens", "", "Comma-separated list of ERC20 contract addresses on zkSync Era")
 	gasSourceFlag := flag.String("gas-source", "", "Path to file containing private key (hex, no 0x) of a wallet with ETH for gas funding")
 	filterKeysFlag := flag.String("filter-keys", "", "Comma-separated list of public addresses to filter (only sweep these)")
+	filterFlag := flag.String("filter-file", "", "Path to file of public addresses to filter (hex, one per line, only sweep these)")
 	rateDelay := flag.Duration("rate-delay", 200*time.Millisecond, "Delay between RPC calls per key")
 	maxFailures := flag.Int("max-failures", 25, "Maximum number of wallet failures before aborting (0 for unlimited)")
 	receiptTimeout := flag.Duration("receipt-timeout", 30*time.Minute, "Maximum time to wait for a transaction to be mined")
@@ -68,8 +69,16 @@ func main() {
 	logger.Info("loaded keys", "count", len(keys))
 
 	// Filter keys if specified.
+	var filterAddrs []common.Address
+	if *filterFlag != "" {
+		addrs, err := sweeper.LoadFilterAddresses(*filterFlag)
+		if err != nil {
+			logger.Error("failed to load filter addresses", "error", err)
+			os.Exit(1)
+		}
+		filterAddrs = append(filterAddrs, addrs...)
+	}
 	if *filterKeysFlag != "" {
-		var filterAddrs []common.Address
 		for _, addrStr := range strings.Split(*filterKeysFlag, ",") {
 			addrStr = strings.TrimSpace(addrStr)
 			if addrStr == "" {
@@ -81,6 +90,8 @@ func main() {
 			}
 			filterAddrs = append(filterAddrs, common.HexToAddress(addrStr))
 		}
+	}
+	if len(filterAddrs) > 0 {
 		keys = sweeper.FilterKeys(keys, filterAddrs)
 		logger.Info("filtered keys", "count", len(keys))
 	}

--- a/tools/sweeper/keys.go
+++ b/tools/sweeper/keys.go
@@ -49,6 +49,36 @@ func LoadKeys(path string) ([]KeyPair, error) {
 	return keys, nil
 }
 
+// LoadFilterAddresses reads public addresses from a file (hex, one per line)
+// and returns them. Empty lines and whitespace are ignored. Lines may optionally
+// include a 0x prefix. All addresses are normalized to lowercase for comparison.
+func LoadFilterAddresses(path string) ([]common.Address, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening filter file: %w", err)
+	}
+	defer f.Close()
+
+	var addrs []common.Address
+	scanner := bufio.NewScanner(f)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if !common.IsHexAddress(line) {
+			return nil, fmt.Errorf("line %d: invalid address: %s", lineNum, line)
+		}
+		addrs = append(addrs, common.HexToAddress(line))
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading filter file: %w", err)
+	}
+	return addrs, nil
+}
+
 // FilterKeys returns only the KeyPairs whose addresses are in the given list.
 func FilterKeys(keys []KeyPair, addresses []common.Address) []KeyPair {
 	allowed := make(map[common.Address]struct{}, len(addresses))

--- a/tools/sweeper/keys_test.go
+++ b/tools/sweeper/keys_test.go
@@ -96,6 +96,87 @@ func TestLoadKeys_FileNotFound(t *testing.T) {
 	}
 }
 
+func TestLoadFilterAddresses_Valid(t *testing.T) {
+	pk1, _ := crypto.GenerateKey()
+	pk2, _ := crypto.GenerateKey()
+	addr1 := crypto.PubkeyToAddress(pk1.PublicKey)
+	addr2 := crypto.PubkeyToAddress(pk2.PublicKey)
+
+	path := writeTestFile(t, addr1.Hex()+"\n"+addr2.Hex()+"\n")
+	addrs, err := LoadFilterAddresses(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(addrs) != 2 {
+		t.Fatalf("expected 2 addresses, got %d", len(addrs))
+	}
+	if addrs[0] != addr1 {
+		t.Fatalf("first address mismatch")
+	}
+	if addrs[1] != addr2 {
+		t.Fatalf("second address mismatch")
+	}
+}
+
+func TestLoadFilterAddresses_LowercaseNoPrefx(t *testing.T) {
+	pk, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(pk.PublicKey)
+	// Write lowercase without 0x prefix.
+	hexStr := fmt.Sprintf("%x", addr.Bytes())
+
+	path := writeTestFile(t, hexStr+"\n")
+	addrs, err := LoadFilterAddresses(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("expected 1 address, got %d", len(addrs))
+	}
+	if addrs[0] != addr {
+		t.Fatalf("address mismatch: got %s, want %s", addrs[0].Hex(), addr.Hex())
+	}
+}
+
+func TestLoadFilterAddresses_EmptyLines(t *testing.T) {
+	pk, _ := crypto.GenerateKey()
+	addr := crypto.PubkeyToAddress(pk.PublicKey)
+
+	path := writeTestFile(t, "\n\n"+addr.Hex()+"\n\n")
+	addrs, err := LoadFilterAddresses(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(addrs) != 1 {
+		t.Fatalf("expected 1 address, got %d", len(addrs))
+	}
+}
+
+func TestLoadFilterAddresses_InvalidAddress(t *testing.T) {
+	path := writeTestFile(t, "not-a-valid-address\n")
+	_, err := LoadFilterAddresses(path)
+	if err == nil {
+		t.Fatal("expected error for invalid address")
+	}
+}
+
+func TestLoadFilterAddresses_EmptyFile(t *testing.T) {
+	path := writeTestFile(t, "")
+	addrs, err := LoadFilterAddresses(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(addrs) != 0 {
+		t.Fatalf("expected 0 addresses, got %d", len(addrs))
+	}
+}
+
+func TestLoadFilterAddresses_FileNotFound(t *testing.T) {
+	_, err := LoadFilterAddresses("/nonexistent/path/filter.txt")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
 func TestFilterKeys_MatchSome(t *testing.T) {
 	pk1, _ := crypto.GenerateKey()
 	pk2, _ := crypto.GenerateKey()


### PR DESCRIPTION
 * Add LoadFilterAddresses function to read hex addresses from a text file (one per line, with or without 0x prefix).
 * The --filter-file and --filter-keys flags can be used together; their addresses are merged.

Change-Id: I137199148cb2d10e95df5afd01bd103ab3c89c4e
