### PR TITLE
tools/sweeper: optimize balance checking with Multicall3

### DIFF
--- a/tools/sweeper/client.go
+++ b/tools/sweeper/client.go
@@ -61,7 +61,10 @@ func retry[T any](ctx context.Context, r *RetryClient, op string, level slog.Lev
 	return backoff.Retry(ctx, func() (T, error) {
 		result, err := fn()
 		if err != nil {
-			r.logger.Log(ctx, level, "retrying RPC call", "op", op, "error", err)
+			var permErr *backoff.PermanentError
+			if !errors.As(err, &permErr) {
+				r.logger.Log(ctx, level, "retrying RPC call", "op", op, "error", err)
+			}
 			return result, err
 		}
 		return result, nil
@@ -109,7 +112,8 @@ func (r *RetryClient) CallContract(ctx context.Context, msg ethereum.CallMsg, bl
 	return retry(ctx, r, "CallContract", slog.LevelWarn, func() ([]byte, error) {
 		result, err := r.client.CallContract(ctx, msg, blockNumber)
 		if err != nil {
-			// Contract reverts (code 3) are deterministic — retrying won't help.
+			// Contract reverts (code 3) are deterministic — wrap as permanent so
+			// the retry loop exits immediately without logging a spurious retry.
 			var rpcErr rpc.Error
 			if errors.As(err, &rpcErr) && rpcErr.ErrorCode() == 3 {
 				return nil, backoff.Permanent(err)

--- a/tools/sweeper/client.go
+++ b/tools/sweeper/client.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package sweeper
 
 import (

--- a/tools/sweeper/client.go
+++ b/tools/sweeper/client.go
@@ -2,6 +2,7 @@ package sweeper
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"math/big"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rpc"
 )
 
 // BlockchainClient defines the interface for interacting with an Ethereum-compatible blockchain.
@@ -103,7 +105,15 @@ func (r *RetryClient) ChainID(ctx context.Context) (*big.Int, error) {
 
 func (r *RetryClient) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
 	return retry(ctx, r, "CallContract", slog.LevelWarn, func() ([]byte, error) {
-		return r.client.CallContract(ctx, msg, blockNumber)
+		result, err := r.client.CallContract(ctx, msg, blockNumber)
+		if err != nil {
+			// Contract reverts (code 3) are deterministic — retrying won't help.
+			var rpcErr rpc.Error
+			if errors.As(err, &rpcErr) && rpcErr.ErrorCode() == 3 {
+				return nil, backoff.Permanent(err)
+			}
+		}
+		return result, err
 	})
 }
 

--- a/tools/sweeper/client_test.go
+++ b/tools/sweeper/client_test.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package sweeper
 
 import (

--- a/tools/sweeper/cmd/sweeper/main.go
+++ b/tools/sweeper/cmd/sweeper/main.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package main
 
 import (

--- a/tools/sweeper/encode_decode_test.go
+++ b/tools/sweeper/encode_decode_test.go
@@ -1,6 +1,0 @@
-// Copyright (C) 2026 Storj Labs, Inc.
-// See LICENSE for copying information.
-
-//go:build ignore
-
-package sweeper

--- a/tools/sweeper/encode_decode_test.go
+++ b/tools/sweeper/encode_decode_test.go
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
+
 //go:build ignore
 
 package sweeper

--- a/tools/sweeper/encode_decode_test.go
+++ b/tools/sweeper/encode_decode_test.go
@@ -1,0 +1,3 @@
+//go:build ignore
+
+package sweeper

--- a/tools/sweeper/erc20.go
+++ b/tools/sweeper/erc20.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package sweeper
 
 import (

--- a/tools/sweeper/erc20_test.go
+++ b/tools/sweeper/erc20_test.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package sweeper
 
 import (

--- a/tools/sweeper/gas.go
+++ b/tools/sweeper/gas.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package sweeper
 
 import (

--- a/tools/sweeper/gas_test.go
+++ b/tools/sweeper/gas_test.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package sweeper
 
 import (

--- a/tools/sweeper/integration_test.go
+++ b/tools/sweeper/integration_test.go
@@ -92,6 +92,10 @@ func TestIntegration_FullSweepFlow(t *testing.T) {
 				return big.NewInt(324), nil
 			},
 			callContractFn: func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+				if msg.To != nil && *msg.To == multicall3Address {
+					n := multicallCallCount(msg.Data)
+					return multicallValueResponse(n, tokenBalanceAmt), nil
+				}
 				result := make([]byte, 32)
 				tokenBalanceAmt.FillBytes(result)
 				return result, nil

--- a/tools/sweeper/integration_test.go
+++ b/tools/sweeper/integration_test.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package sweeper
 
 import (

--- a/tools/sweeper/keys.go
+++ b/tools/sweeper/keys.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package sweeper
 
 import (

--- a/tools/sweeper/keys_test.go
+++ b/tools/sweeper/keys_test.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package sweeper
 
 import (

--- a/tools/sweeper/multicall.go
+++ b/tools/sweeper/multicall.go
@@ -236,13 +236,19 @@ func decodeAggregate3Results(data []byte, n int) ([][]byte, error) {
 		return nil, fmt.Errorf("response too short: %d bytes", len(data))
 	}
 
-	arrayStart := int(new(big.Int).SetBytes(safeSlice(data, 0, 32)).Uint64())
+	arrayStart, err := decodeOffset(data, 0, "array start")
+	if err != nil {
+		return nil, err
+	}
 	if arrayStart+32 > len(data) {
 		return nil, fmt.Errorf("array start out of bounds")
 	}
 	// arrayContent is where the length word + offset table live; offsets are relative to it.
 	arrayContent := arrayStart
-	arrayLen := int(new(big.Int).SetBytes(safeSlice(data, arrayContent, arrayContent+32)).Uint64())
+	arrayLen, err := decodeOffset(data, arrayContent, "array length")
+	if err != nil {
+		return nil, err
+	}
 	if arrayLen != n {
 		return nil, fmt.Errorf("unexpected result count: got %d, want %d", arrayLen, n)
 	}
@@ -258,7 +264,10 @@ func decodeAggregate3Results(data []byte, n int) ([][]byte, error) {
 		if offWord+32 > len(data) {
 			return nil, fmt.Errorf("element %d offset word out of bounds", i)
 		}
-		elemRelOff := int(new(big.Int).SetBytes(safeSlice(data, offWord, offWord+32)).Uint64())
+		elemRelOff, err := decodeOffset(data, offWord, fmt.Sprintf("element %d offset", i))
+		if err != nil {
+			return nil, err
+		}
 		elemStart := offsetTableBase + elemRelOff
 
 		// Element layout: success(32) + bytesOffset(32) + bytesLen(32) + bytes
@@ -268,13 +277,19 @@ func decodeAggregate3Results(data []byte, n int) ([][]byte, error) {
 		success := data[elemStart+31] != 0
 
 		// offset to returnData bytes, relative to start of this element
-		bytesRelOff := int(new(big.Int).SetBytes(safeSlice(data, elemStart+32, elemStart+64)).Uint64())
+		bytesRelOff, err := decodeOffset(data, elemStart+32, fmt.Sprintf("element %d bytes offset", i))
+		if err != nil {
+			return nil, err
+		}
 		bytesLenOff := elemStart + bytesRelOff
 		if bytesLenOff+32 > len(data) {
 			return nil, fmt.Errorf("element %d data offset out of bounds", i)
 		}
 
-		bytesLen := int(new(big.Int).SetBytes(safeSlice(data, bytesLenOff, bytesLenOff+32)).Uint64())
+		bytesLen, err := decodeOffset(data, bytesLenOff, fmt.Sprintf("element %d bytes length", i))
+		if err != nil {
+			return nil, err
+		}
 		if bytesLenOff+32+bytesLen > len(data) {
 			return nil, fmt.Errorf("element %d data out of bounds", i)
 		}
@@ -314,6 +329,17 @@ func appendUint256(buf []byte, v uint64) []byte {
 	var word [32]byte
 	binary.BigEndian.PutUint64(word[24:], v)
 	return append(buf, word[:]...)
+}
+
+// decodeOffset reads a 32-byte ABI word from data[off:off+32] and returns it
+// as a non-negative int. Returns an error if the value exceeds the length of
+// data, guarding against malformed responses causing negative slice indices.
+func decodeOffset(data []byte, off int, label string) (int, error) {
+	raw := new(big.Int).SetBytes(safeSlice(data, off, off+32))
+	if !raw.IsInt64() || raw.Int64() < 0 || raw.Int64() > int64(len(data)) {
+		return 0, fmt.Errorf("%s out of range: %s", label, raw)
+	}
+	return int(raw.Int64()), nil
 }
 
 func safeSlice(data []byte, from, to int) []byte {

--- a/tools/sweeper/multicall.go
+++ b/tools/sweeper/multicall.go
@@ -20,9 +20,8 @@ var multicall3Address = common.HexToAddress("0xcA11bde05977b3631167028862bE2a173
 var aggregate3MethodID = [4]byte{0x82, 0xad, 0x56, 0xcb}
 
 // multicallBatchSize is the number of individual calls packed into one eth_call.
-// 500 is conservative enough to stay well within gas and response-size limits
-// across most RPC providers.
-const multicallBatchSize = 500
+// Kept at 100 to stay within Infura's eth_call sub-call limits on standard tiers.
+const multicallBatchSize = 100
 
 // WalletBalances holds the ETH and ERC20 balances for a single wallet returned
 // by a multicall query.

--- a/tools/sweeper/multicall.go
+++ b/tools/sweeper/multicall.go
@@ -225,7 +225,7 @@ func encodeAggregate3(calls []callDesc) ([]byte, error) {
 //
 //	[0]   outer offset (0x20) → array content starts at [32]
 //	[32]  array length n
-//	[64]  n × per-element offset words (relative to start of array content, i.e. [32])
+//	[64]  n × per-element offset words (relative to start of offset table, i.e. [64])
 //	      each offset points to the element encoding:
 //	        success (32 bytes)
 //	        offset to returnData bytes relative to start of element (32 bytes, always 0x40)

--- a/tools/sweeper/multicall.go
+++ b/tools/sweeper/multicall.go
@@ -1,0 +1,331 @@
+package sweeper
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// multicall3Address is the canonical Multicall3 deployment address, the same
+// on Ethereum mainnet, zkSync Era, and virtually every other EVM chain.
+// See https://github.com/mds1/multicall
+var multicall3Address = common.HexToAddress("0xcA11bde05977b3631167028862bE2a173976CA11")
+
+// aggregate3MethodID is the 4-byte selector for aggregate3((address,bool,bytes)[]).
+var aggregate3MethodID = [4]byte{0x82, 0xad, 0x56, 0xcb}
+
+// multicallBatchSize is the number of individual calls packed into one eth_call.
+// 500 is conservative enough to stay well within gas and response-size limits
+// across most RPC providers.
+const multicallBatchSize = 500
+
+// WalletBalances holds the ETH and ERC20 balances for a single wallet returned
+// by a multicall query.
+type WalletBalances struct {
+	ETH    *big.Int
+	Tokens []*big.Int // parallel to the tokens slice passed to MulticallBalances
+}
+
+// HasFunds returns true if any balance is non-zero.
+func (wb WalletBalances) HasFunds() bool {
+	if wb.ETH != nil && wb.ETH.Sign() > 0 {
+		return true
+	}
+	for _, t := range wb.Tokens {
+		if t != nil && t.Sign() > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// callDesc describes a single sub-call within an aggregate3 batch.
+type callDesc struct {
+	walletIdx int
+	tokenIdx  int // -1 means ETH balance
+	target    common.Address
+	data      []byte
+}
+
+// MulticallBalances queries ETH and ERC20 balances for all wallets in batches
+// using Multicall3. Returns one WalletBalances per entry in wallets, in the
+// same order. ETH balances at or below minETH are treated as dust and zeroed
+// out; pass nil to keep all positive ETH balances.
+func MulticallBalances(ctx context.Context, logger *slog.Logger, client BlockchainClient, wallets []common.Address, tokens []common.Address, minETH *big.Int) ([]WalletBalances, error) {
+	if len(wallets) == 0 {
+		return nil, nil
+	}
+
+	// Number of calls per wallet: 1 ETH balance + 1 per token.
+	callsPerWallet := 1 + len(tokens)
+	totalCalls := len(wallets) * callsPerWallet
+
+	allCalls := make([]callDesc, 0, totalCalls)
+	for wi, wallet := range wallets {
+		// ETH balance via Multicall3.getEthBalance(address)
+		allCalls = append(allCalls, callDesc{
+			walletIdx: wi,
+			tokenIdx:  -1,
+			target:    multicall3Address,
+			data:      encodeGetEthBalance(wallet),
+		})
+		// ERC20 balanceOf(wallet) for each token
+		for ti, token := range tokens {
+			allCalls = append(allCalls, callDesc{
+				walletIdx: wi,
+				tokenIdx:  ti,
+				target:    token,
+				data:      encodeBalanceOf(wallet),
+			})
+		}
+	}
+
+	results := make([]WalletBalances, len(wallets))
+	for i := range results {
+		results[i].ETH = new(big.Int)
+		results[i].Tokens = make([]*big.Int, len(tokens))
+		for j := range results[i].Tokens {
+			results[i].Tokens[j] = new(big.Int)
+		}
+	}
+
+	// Process in batches.
+	totalBatches := (len(allCalls) + multicallBatchSize - 1) / multicallBatchSize
+	for start := 0; start < len(allCalls); start += multicallBatchSize {
+		end := start + multicallBatchSize
+		if end > len(allCalls) {
+			end = len(allCalls)
+		}
+		batch := allCalls[start:end]
+		batchNum := start/multicallBatchSize + 1
+		logger.Info("executing multicall batch", "batch", batchNum, "of", totalBatches, "calls", len(batch))
+
+		raw, err := callAggregate3(ctx, client, batch)
+		if err != nil {
+			return nil, fmt.Errorf("multicall batch %d-%d: %w", start, end, err)
+		}
+
+		for i, cd := range batch {
+			val := new(big.Int).SetBytes(raw[i])
+			if cd.tokenIdx == -1 {
+				if minETH != nil && val.Cmp(minETH) <= 0 {
+					val = new(big.Int) // treat as dust
+				}
+				results[cd.walletIdx].ETH = val
+			} else {
+				results[cd.walletIdx].Tokens[cd.tokenIdx] = val
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// callAggregate3 encodes and executes a single aggregate3 call, returning the
+// raw 32-byte return data for each sub-call (only successful ones are expected;
+// allowFailure is false for all).
+func callAggregate3(ctx context.Context, client BlockchainClient, calls []callDesc) ([][]byte, error) {
+	calldata, err := encodeAggregate3(calls)
+	if err != nil {
+		return nil, err
+	}
+
+	mc := multicall3Address
+	result, err := client.CallContract(ctx, ethereum.CallMsg{
+		To:   &mc,
+		Data: calldata,
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("eth_call: %w", err)
+	}
+
+	return decodeAggregate3Results(result, len(calls))
+}
+
+// encodeAggregate3 ABI-encodes the aggregate3 call for the given set of calls.
+//
+// aggregate3((address target, bool allowFailure, bytes callData)[])
+//
+// ABI layout (all offsets in 32-byte words):
+//
+//	[0]  selector (4 bytes) + offset to array (32 bytes) = 36 bytes head
+//	     offset = 0x20 (points past the 32-byte length word)
+//	[1]  array length
+//	[2+] array elements, each tuple encoded inline:
+//	       word 0: target address (right-padded to 32 bytes)
+//	       word 1: allowFailure bool (0)
+//	       word 2: offset to callData bytes (relative to start of this tuple)
+//	       ...callData bytes...
+func encodeAggregate3(calls []callDesc) ([]byte, error) {
+	n := len(calls)
+
+	// Each call has fixed head: target(32) + allowFailure(32) + dataOffset(32) = 96 bytes
+	// plus the bytes payload: length(32) + data padded to 32-byte boundary.
+	// We also need the outer ABI head: selector(4) + arrayOffset(32) + arrayLen(32).
+
+	// First pass: compute per-element data sizes and total size.
+	type encodedCall struct {
+		target [32]byte
+		data   []byte
+	}
+	encoded := make([]encodedCall, n)
+	for i, c := range calls {
+		copy(encoded[i].target[12:], c.target.Bytes())
+		encoded[i].data = c.data
+	}
+
+	// Build the buffer.
+	// Outer header: 4 (selector) + 32 (array offset = 0x20) + 32 (array length)
+	// Per element head (3 words each): 96 bytes
+	// Per element tail: 32 (data length) + len(data) rounded up to 32
+	buf := make([]byte, 0, 4+32+32+n*96)
+
+	// selector
+	buf = append(buf, aggregate3MethodID[:]...)
+
+	// offset to array (0x20 = 32, pointing right after this word)
+	buf = appendUint256(buf, 0x20)
+
+	// array length
+	buf = appendUint256(buf, uint64(n))
+
+	// For each call we need to know the offset of its `bytes callData` relative
+	// to the start of the tuple. Each tuple head is 3 words (96 bytes). The
+	// bytes data for call i starts after all the tuple heads of all n calls,
+	// then after all the bytes payloads of calls 0..i-1.
+	//
+	// offset_i = (n-i-1)*96 (remaining heads after this tuple's head)
+	//           + sum(32 + roundUp32(len(data[j])) for j < i)
+	//
+	// We build the heads first, then append the tails.
+
+	tailBuf := make([]byte, 0, n*64)
+	dataOffset := uint64((n) * 96) // offset from start of first tuple to first tail
+
+	// We need to track the running offset into tails for each element.
+	offsets := make([]uint64, n)
+	runningOffset := uint64(0)
+	for i, ec := range encoded {
+		offsets[i] = dataOffset - uint64(i)*96 + runningOffset
+		_ = ec
+		dataLen := uint64(len(encoded[i].data))
+		paddedLen := (dataLen + 31) &^ 31
+		runningOffset += 32 + paddedLen
+	}
+
+	for i, ec := range encoded {
+		// target
+		buf = append(buf, ec.target[:]...)
+		// allowFailure = false
+		buf = appendUint256(buf, 0)
+		// offset to callData bytes, relative to start of this tuple
+		buf = appendUint256(buf, offsets[i])
+
+		// tail: length + padded data
+		dataLen := uint64(len(ec.data))
+		paddedLen := (dataLen + 31) &^ 31
+		tailBuf = appendUint256(tailBuf, dataLen)
+		tailBuf = append(tailBuf, ec.data...)
+		for pad := dataLen; pad < paddedLen; pad++ {
+			tailBuf = append(tailBuf, 0)
+		}
+	}
+
+	buf = append(buf, tailBuf...)
+	return buf, nil
+}
+
+// decodeAggregate3Results decodes the ABI-encoded return value of aggregate3.
+//
+// Return type: (bool success, bytes returnData)[]
+//
+// Layout:
+//
+//	[0]  offset to array (0x20)
+//	[1]  array length
+//	[2+] per-element: success(32) + dataOffset(32) ... bytes data
+func decodeAggregate3Results(data []byte, n int) ([][]byte, error) {
+	// Minimum: 32 (outer offset) + 32 (length) = 64 bytes
+	if len(data) < 64 {
+		return nil, fmt.Errorf("response too short: %d bytes", len(data))
+	}
+
+	// outer offset (we trust it's 0x20)
+	arrayStart := int(new(big.Int).SetBytes(safeSlice(data, 0, 32)).Uint64())
+	if arrayStart+32 > len(data) {
+		return nil, fmt.Errorf("array start out of bounds")
+	}
+	arrayLen := int(new(big.Int).SetBytes(safeSlice(data, arrayStart, arrayStart+32)).Uint64())
+	if arrayLen != n {
+		return nil, fmt.Errorf("unexpected result count: got %d, want %d", arrayLen, n)
+	}
+
+	// Each element head is at arrayStart+32 + i*64 (success word + data-offset word).
+	results := make([][]byte, n)
+	elemBase := arrayStart + 32
+	for i := range n {
+		elemHeadOff := elemBase + i*64
+		if elemHeadOff+64 > len(data) {
+			return nil, fmt.Errorf("element %d head out of bounds", i)
+		}
+
+		// success word
+		success := data[elemHeadOff+31] != 0
+
+		// offset to bytes returnData, relative to start of array content (elemBase)
+		dataRelOff := int(new(big.Int).SetBytes(safeSlice(data, elemHeadOff+32, elemHeadOff+64)).Uint64())
+		dataAbsOff := elemBase + dataRelOff
+		if dataAbsOff+32 > len(data) {
+			return nil, fmt.Errorf("element %d data offset out of bounds", i)
+		}
+
+		bytesLen := int(new(big.Int).SetBytes(safeSlice(data, dataAbsOff, dataAbsOff+32)).Uint64())
+		if dataAbsOff+32+bytesLen > len(data) {
+			return nil, fmt.Errorf("element %d data out of bounds", i)
+		}
+		payload := data[dataAbsOff+32 : dataAbsOff+32+bytesLen]
+
+		if !success || len(payload) < 32 {
+			// Treat failed or empty calls as zero balance.
+			results[i] = make([]byte, 32)
+		} else {
+			results[i] = payload[len(payload)-32:]
+		}
+	}
+	return results, nil
+}
+
+// encodeGetEthBalance encodes Multicall3.getEthBalance(address).
+// selector: 0x4d2301cc
+func encodeGetEthBalance(addr common.Address) []byte {
+	data := make([]byte, 4+32)
+	data[0], data[1], data[2], data[3] = 0x4d, 0x23, 0x01, 0xcc
+	copy(data[4+12:], addr.Bytes())
+	return data
+}
+
+// encodeBalanceOf encodes ERC20 balanceOf(address).
+func encodeBalanceOf(addr common.Address) []byte {
+	data := make([]byte, 4+32)
+	copy(data[0:4], balanceOfMethodID[:])
+	copy(data[4+12:], addr.Bytes())
+	return data
+}
+
+func appendUint256(buf []byte, v uint64) []byte {
+	var word [32]byte
+	binary.BigEndian.PutUint64(word[24:], v)
+	return append(buf, word[:]...)
+}
+
+func safeSlice(data []byte, from, to int) []byte {
+	if to > len(data) {
+		return make([]byte, to-from)
+	}
+	return data[from:to]
+}

--- a/tools/sweeper/multicall.go
+++ b/tools/sweeper/multicall.go
@@ -20,7 +20,7 @@ var multicall3Address = common.HexToAddress("0xcA11bde05977b3631167028862bE2a173
 var aggregate3MethodID = [4]byte{0x82, 0xad, 0x56, 0xcb}
 
 // multicallBatchSize is the number of individual calls packed into one eth_call.
-// Kept at 100 to stay within Infura's eth_call sub-call limits on standard tiers.
+// Kept at 100 to stay within RPC provider eth_call sub-call limits.
 const multicallBatchSize = 100
 
 // WalletBalances holds the ETH and ERC20 balances for a single wallet returned
@@ -220,8 +220,8 @@ func encodeAggregate3(calls []callDesc) ([]byte, error) {
 	for i, ec := range encoded {
 		// target
 		buf = append(buf, ec.target[:]...)
-		// allowFailure = false
-		buf = appendUint256(buf, 0)
+		// allowFailure = true — individual sub-call failures return zero rather than reverting the batch
+		buf = appendUint256(buf, 1)
 		// offset to callData bytes, relative to start of this tuple
 		buf = appendUint256(buf, offsets[i])
 

--- a/tools/sweeper/multicall.go
+++ b/tools/sweeper/multicall.go
@@ -219,54 +219,67 @@ func encodeAggregate3(calls []callDesc) ([]byte, error) {
 //
 // Return type: (bool success, bytes returnData)[]
 //
-// Layout:
+// Because the tuple contains a bytes field it is dynamic, so the array uses a
+// per-element offset table (same two-level indirection as the encoding):
 //
-//	[0]  offset to array (0x20)
-//	[1]  array length
-//	[2+] per-element: success(32) + dataOffset(32) ... bytes data
+//	[0]   outer offset (0x20) → array content starts at [32]
+//	[32]  array length n
+//	[64]  n × per-element offset words (relative to start of array content, i.e. [32])
+//	      each offset points to the element encoding:
+//	        success (32 bytes)
+//	        offset to returnData bytes relative to start of element (32 bytes, always 0x40)
+//	        bytes length (32 bytes)
+//	        bytes data (padded to 32)
 func decodeAggregate3Results(data []byte, n int) ([][]byte, error) {
-	// Minimum: 32 (outer offset) + 32 (length) = 64 bytes
 	if len(data) < 64 {
 		return nil, fmt.Errorf("response too short: %d bytes", len(data))
 	}
 
-	// outer offset (we trust it's 0x20)
 	arrayStart := int(new(big.Int).SetBytes(safeSlice(data, 0, 32)).Uint64())
 	if arrayStart+32 > len(data) {
 		return nil, fmt.Errorf("array start out of bounds")
 	}
-	arrayLen := int(new(big.Int).SetBytes(safeSlice(data, arrayStart, arrayStart+32)).Uint64())
+	// arrayContent is where the length word + offset table live; offsets are relative to it.
+	arrayContent := arrayStart
+	arrayLen := int(new(big.Int).SetBytes(safeSlice(data, arrayContent, arrayContent+32)).Uint64())
 	if arrayLen != n {
 		return nil, fmt.Errorf("unexpected result count: got %d, want %d", arrayLen, n)
 	}
 
-	// Each element head is at arrayStart+32 + i*64 (success word + data-offset word).
+	// Per-element offset table starts right after the length word.
+	// Each offset is relative to the start of the offset table (not arrayContent).
+	offsetTableBase := arrayContent + 32
+
 	results := make([][]byte, n)
-	elemBase := arrayStart + 32
 	for i := range n {
-		elemHeadOff := elemBase + i*64
-		if elemHeadOff+64 > len(data) {
+		// Read the per-element offset (relative to offsetTableBase).
+		offWord := offsetTableBase + i*32
+		if offWord+32 > len(data) {
+			return nil, fmt.Errorf("element %d offset word out of bounds", i)
+		}
+		elemRelOff := int(new(big.Int).SetBytes(safeSlice(data, offWord, offWord+32)).Uint64())
+		elemStart := offsetTableBase + elemRelOff
+
+		// Element layout: success(32) + bytesOffset(32) + bytesLen(32) + bytes
+		if elemStart+64 > len(data) {
 			return nil, fmt.Errorf("element %d head out of bounds", i)
 		}
+		success := data[elemStart+31] != 0
 
-		// success word
-		success := data[elemHeadOff+31] != 0
-
-		// offset to bytes returnData, relative to start of array content (elemBase)
-		dataRelOff := int(new(big.Int).SetBytes(safeSlice(data, elemHeadOff+32, elemHeadOff+64)).Uint64())
-		dataAbsOff := elemBase + dataRelOff
-		if dataAbsOff+32 > len(data) {
+		// offset to returnData bytes, relative to start of this element
+		bytesRelOff := int(new(big.Int).SetBytes(safeSlice(data, elemStart+32, elemStart+64)).Uint64())
+		bytesLenOff := elemStart + bytesRelOff
+		if bytesLenOff+32 > len(data) {
 			return nil, fmt.Errorf("element %d data offset out of bounds", i)
 		}
 
-		bytesLen := int(new(big.Int).SetBytes(safeSlice(data, dataAbsOff, dataAbsOff+32)).Uint64())
-		if dataAbsOff+32+bytesLen > len(data) {
+		bytesLen := int(new(big.Int).SetBytes(safeSlice(data, bytesLenOff, bytesLenOff+32)).Uint64())
+		if bytesLenOff+32+bytesLen > len(data) {
 			return nil, fmt.Errorf("element %d data out of bounds", i)
 		}
-		payload := data[dataAbsOff+32 : dataAbsOff+32+bytesLen]
+		payload := data[bytesLenOff+32 : bytesLenOff+32+bytesLen]
 
 		if !success || len(payload) < 32 {
-			// Treat failed or empty calls as zero balance.
 			results[i] = make([]byte, 32)
 		} else {
 			results[i] = payload[len(payload)-32:]

--- a/tools/sweeper/multicall.go
+++ b/tools/sweeper/multicall.go
@@ -20,8 +20,7 @@ var multicall3Address = common.HexToAddress("0xcA11bde05977b3631167028862bE2a173
 var aggregate3MethodID = [4]byte{0x82, 0xad, 0x56, 0xcb}
 
 // multicallBatchSize is the number of individual calls packed into one eth_call.
-// Kept at 100 to stay within RPC provider eth_call sub-call limits.
-const multicallBatchSize = 100
+const multicallBatchSize = 500
 
 // WalletBalances holds the ETH and ERC20 balances for a single wallet returned
 // by a multicall query.

--- a/tools/sweeper/multicall.go
+++ b/tools/sweeper/multicall.go
@@ -279,6 +279,10 @@ func decodeAggregate3Results(data []byte, n int) ([][]byte, error) {
 		payload := data[bytesLenOff+32 : bytesLenOff+32+bytesLen]
 
 		if !success || len(payload) < 32 {
+			// Sub-call failed (allowFailure=true) or returned no data — treat as
+			// zero balance. Token addresses are operator-configured, so a reverting
+			// balanceOf most likely means the contract isn't a standard ERC20 at
+			// that address on this network, not that the wallet has funds we'd miss.
 			results[i] = make([]byte, 32)
 		} else {
 			results[i] = payload[len(payload)-32:]

--- a/tools/sweeper/multicall.go
+++ b/tools/sweeper/multicall.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package sweeper
 
 import (

--- a/tools/sweeper/multicall.go
+++ b/tools/sweeper/multicall.go
@@ -150,92 +150,68 @@ func callAggregate3(ctx context.Context, client BlockchainClient, calls []callDe
 //
 // aggregate3((address target, bool allowFailure, bytes callData)[])
 //
-// ABI layout (all offsets in 32-byte words):
+// The array element type is a dynamic tuple (it contains a `bytes` field), so
+// the ABI encoding requires two layers of indirection:
 //
-//	[0]  selector (4 bytes) + offset to array (32 bytes) = 36 bytes head
-//	     offset = 0x20 (points past the 32-byte length word)
-//	[1]  array length
-//	[2+] array elements, each tuple encoded inline:
-//	       word 0: target address (right-padded to 32 bytes)
-//	       word 1: allowFailure bool (0)
-//	       word 2: offset to callData bytes (relative to start of this tuple)
-//	       ...callData bytes...
+//	selector (4 bytes)
+//	offset to array content (0x20)          ← points past this word
+//	array length (n)
+//	n × per-element offset words            ← each points to that element's encoding
+//	n × element encodings, each:
+//	  target       (32 bytes)
+//	  allowFailure (32 bytes, 1 = true)
+//	  offset to callData bytes (relative to start of this element's encoding, always 0x60)
+//	  callData length (32 bytes)
+//	  callData padded to 32-byte boundary
 func encodeAggregate3(calls []callDesc) ([]byte, error) {
 	n := len(calls)
 
-	// Each call has fixed head: target(32) + allowFailure(32) + dataOffset(32) = 96 bytes
-	// plus the bytes payload: length(32) + data padded to 32-byte boundary.
-	// We also need the outer ABI head: selector(4) + arrayOffset(32) + arrayLen(32).
-
-	// First pass: compute per-element data sizes and total size.
-	type encodedCall struct {
-		target [32]byte
-		data   []byte
-	}
-	encoded := make([]encodedCall, n)
+	// Compute per-element encoded sizes for building the element-offset table.
+	// Each element encodes as: 3×32 (head) + 32 (bytes length) + roundUp32(data).
+	elemSizes := make([]uint64, n)
 	for i, c := range calls {
-		copy(encoded[i].target[12:], c.target.Bytes())
-		encoded[i].data = c.data
+		dataLen := uint64(len(c.data))
+		paddedLen := (dataLen + 31) &^ 31
+		elemSizes[i] = 96 + 32 + paddedLen
 	}
 
-	// Build the buffer.
-	// Outer header: 4 (selector) + 32 (array offset = 0x20) + 32 (array length)
-	// Per element head (3 words each): 96 bytes
-	// Per element tail: 32 (data length) + len(data) rounded up to 32
-	buf := make([]byte, 0, 4+32+32+n*96)
+	// Per-element offset table: offsets are relative to the start of array content
+	// (right after the length word). The table itself is n×32 bytes; element i
+	// starts after the table and all preceding elements.
+	elemOffsets := make([]uint64, n)
+	base := uint64(n * 32) // table size
+	for i := range n {
+		elemOffsets[i] = base
+		base += elemSizes[i]
+	}
 
-	// selector
+	var buf []byte
 	buf = append(buf, aggregate3MethodID[:]...)
-
-	// offset to array (0x20 = 32, pointing right after this word)
-	buf = appendUint256(buf, 0x20)
-
-	// array length
+	buf = appendUint256(buf, 0x20) // offset to array content
 	buf = appendUint256(buf, uint64(n))
 
-	// For each call we need to know the offset of its `bytes callData` relative
-	// to the start of the tuple. Each tuple head is 3 words (96 bytes). The
-	// bytes data for call i starts after all the tuple heads of all n calls,
-	// then after all the bytes payloads of calls 0..i-1.
-	//
-	// offset_i = (n-i-1)*96 (remaining heads after this tuple's head)
-	//           + sum(32 + roundUp32(len(data[j])) for j < i)
-	//
-	// We build the heads first, then append the tails.
-
-	tailBuf := make([]byte, 0, n*64)
-	dataOffset := uint64((n) * 96) // offset from start of first tuple to first tail
-
-	// We need to track the running offset into tails for each element.
-	offsets := make([]uint64, n)
-	runningOffset := uint64(0)
-	for i, ec := range encoded {
-		offsets[i] = dataOffset - uint64(i)*96 + runningOffset
-		_ = ec
-		dataLen := uint64(len(encoded[i].data))
-		paddedLen := (dataLen + 31) &^ 31
-		runningOffset += 32 + paddedLen
+	// Per-element offset table.
+	for _, off := range elemOffsets {
+		buf = appendUint256(buf, off)
 	}
 
-	for i, ec := range encoded {
-		// target
-		buf = append(buf, ec.target[:]...)
-		// allowFailure = true — individual sub-call failures return zero rather than reverting the batch
-		buf = appendUint256(buf, 1)
-		// offset to callData bytes, relative to start of this tuple
-		buf = appendUint256(buf, offsets[i])
+	// Element encodings.
+	for _, c := range calls {
+		var target [32]byte
+		copy(target[12:], c.target.Bytes())
+		buf = append(buf, target[:]...)
+		buf = appendUint256(buf, 1)    // allowFailure = true
+		buf = appendUint256(buf, 0x60) // offset to callData bytes relative to this element (always 3×32)
 
-		// tail: length + padded data
-		dataLen := uint64(len(ec.data))
+		dataLen := uint64(len(c.data))
 		paddedLen := (dataLen + 31) &^ 31
-		tailBuf = appendUint256(tailBuf, dataLen)
-		tailBuf = append(tailBuf, ec.data...)
+		buf = appendUint256(buf, dataLen)
+		buf = append(buf, c.data...)
 		for pad := dataLen; pad < paddedLen; pad++ {
-			tailBuf = append(tailBuf, 0)
+			buf = append(buf, 0)
 		}
 	}
 
-	buf = append(buf, tailBuf...)
 	return buf, nil
 }
 

--- a/tools/sweeper/multicall.go
+++ b/tools/sweeper/multicall.go
@@ -125,8 +125,8 @@ func MulticallBalances(ctx context.Context, logger *slog.Logger, client Blockcha
 }
 
 // callAggregate3 encodes and executes a single aggregate3 call, returning the
-// raw 32-byte return data for each sub-call (only successful ones are expected;
-// allowFailure is false for all).
+// raw 32-byte return data for each sub-call. allowFailure is true for all
+// sub-calls; failed ones are decoded as zero by decodeAggregate3Results.
 func callAggregate3(ctx context.Context, client BlockchainClient, calls []callDesc) ([][]byte, error) {
 	calldata, err := encodeAggregate3(calls)
 	if err != nil {

--- a/tools/sweeper/multicall_test.go
+++ b/tools/sweeper/multicall_test.go
@@ -1,0 +1,255 @@
+package sweeper
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// encodeAggregate3Response builds a synthetic aggregate3 return value for
+// testing. Each value in vals is encoded as a successful (bool success, bytes
+// returnData) tuple where returnData is the 32-byte big-endian representation
+// of the value.
+func encodeAggregate3Response(vals []*big.Int) []byte {
+	n := len(vals)
+
+	// Layout (all sizes in bytes):
+	//   32  outer offset (= 0x20)
+	//   32  array length
+	//   n*64  element heads: success(32) + dataOffset(32)
+	//   n*64  element tails: bytesLen(32) + 32-byte payload
+
+	// dataOffset for element i is relative to the start of the array content
+	// (i.e., right after the outer-offset and length words).
+	// Array content starts at byte 64 (0x40) from the start of the return data.
+	// Element heads occupy n*64 bytes.
+	// Element i's tail starts at n*64 + i*64 bytes from the start of array content.
+
+	buf := make([]byte, 0, 64+n*128)
+
+	// outer offset
+	buf = appendUint256(buf, 0x20)
+	// array length
+	buf = appendUint256(buf, uint64(n))
+
+	// heads
+	for i := range n {
+		// success = true
+		buf = appendUint256(buf, 1)
+		// offset to bytes returnData, relative to start of array content (after length word)
+		// = n*64 (all heads) + i*64 (preceding tails)
+		buf = appendUint256(buf, uint64(n*64+i*64))
+	}
+
+	// tails
+	for _, v := range vals {
+		// bytes length = 32
+		buf = appendUint256(buf, 32)
+		// 32-byte value
+		var word [32]byte
+		v.FillBytes(word[:])
+		buf = append(buf, word[:]...)
+	}
+
+	return buf
+}
+
+func TestMulticallBalances_AllZero(t *testing.T) {
+	wallet := common.HexToAddress("0x1111")
+	token := common.HexToAddress("0xtoken")
+
+	mock := &mockClient{
+		callContractFn: func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			// 2 calls: ETH balance + 1 token balance, both zero
+			return encodeAggregate3Response([]*big.Int{big.NewInt(0), big.NewInt(0)}), nil
+		},
+	}
+
+	results, err := MulticallBalances(context.Background(), testLogger(), mock, []common.Address{wallet}, []common.Address{token}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].HasFunds() {
+		t.Fatal("expected no funds")
+	}
+}
+
+func TestMulticallBalances_ETHNonZero(t *testing.T) {
+	wallet := common.HexToAddress("0x1111")
+
+	mock := &mockClient{
+		callContractFn: func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			return encodeAggregate3Response([]*big.Int{big.NewInt(1e18)}), nil
+		},
+	}
+
+	results, err := MulticallBalances(context.Background(), testLogger(), mock, []common.Address{wallet}, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !results[0].HasFunds() {
+		t.Fatal("expected funds")
+	}
+	if results[0].ETH.Cmp(big.NewInt(1e18)) != 0 {
+		t.Fatalf("unexpected ETH balance: %v", results[0].ETH)
+	}
+}
+
+func TestMulticallBalances_TokenNonZero(t *testing.T) {
+	wallet := common.HexToAddress("0x1111")
+	token := common.HexToAddress("0xtoken")
+
+	mock := &mockClient{
+		callContractFn: func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			// ETH=0, token=500
+			return encodeAggregate3Response([]*big.Int{big.NewInt(0), big.NewInt(500)}), nil
+		},
+	}
+
+	results, err := MulticallBalances(context.Background(), testLogger(), mock, []common.Address{wallet}, []common.Address{token}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !results[0].HasFunds() {
+		t.Fatal("expected funds")
+	}
+	if results[0].Tokens[0].Cmp(big.NewInt(500)) != 0 {
+		t.Fatalf("unexpected token balance: %v", results[0].Tokens[0])
+	}
+}
+
+func TestMulticallBalances_MultipleWallets(t *testing.T) {
+	wallets := []common.Address{
+		common.HexToAddress("0x1111"),
+		common.HexToAddress("0x2222"),
+		common.HexToAddress("0x3333"),
+	}
+
+	// No tokens — one ETH balance call per wallet, so 3 values total in one batch.
+	mock := &mockClient{
+		callContractFn: func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			return encodeAggregate3Response([]*big.Int{
+				big.NewInt(0),    // wallet 0: empty
+				big.NewInt(1e18), // wallet 1: has ETH
+				big.NewInt(0),    // wallet 2: empty
+			}), nil
+		},
+	}
+
+	results, err := MulticallBalances(context.Background(), testLogger(), mock, wallets, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results[0].HasFunds() {
+		t.Fatal("wallet 0 should have no funds")
+	}
+	if !results[1].HasFunds() {
+		t.Fatal("wallet 1 should have funds")
+	}
+	if results[2].HasFunds() {
+		t.Fatal("wallet 2 should have no funds")
+	}
+}
+
+func TestMulticallBalances_Batching(t *testing.T) {
+	// Create enough wallets to require 2 batches (batchSize=500, one call each).
+	n := multicallBatchSize + 10
+	wallets := make([]common.Address, n)
+	for i := range wallets {
+		wallets[i] = common.BigToAddress(big.NewInt(int64(i + 1)))
+	}
+
+	var batchCount int
+	mock := &mockClient{
+		callContractFn: func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			batchCount++
+			// Figure out how many calls are in this batch from the calldata length
+			// and return the right number of zero values.
+			// We can't easily decode the calldata here, so return a fixed-size
+			// response matching the expected batch size.
+			size := multicallBatchSize
+			if batchCount == 2 {
+				size = 10
+			}
+			vals := make([]*big.Int, size)
+			for i := range vals {
+				vals[i] = big.NewInt(0)
+			}
+			return encodeAggregate3Response(vals), nil
+		},
+	}
+
+	results, err := MulticallBalances(context.Background(), testLogger(), mock, wallets, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != n {
+		t.Fatalf("expected %d results, got %d", n, len(results))
+	}
+	if batchCount != 2 {
+		t.Fatalf("expected 2 batches, got %d", batchCount)
+	}
+}
+
+func TestMulticallBalances_Empty(t *testing.T) {
+	mock := &mockClient{}
+	results, err := MulticallBalances(context.Background(), testLogger(), mock, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected empty results, got %d", len(results))
+	}
+}
+
+func TestMulticallBalances_RPCError(t *testing.T) {
+	wallet := common.HexToAddress("0x1111")
+
+	mock := &mockClient{
+		callContractFn: func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			return nil, context.DeadlineExceeded
+		},
+	}
+
+	_, err := MulticallBalances(context.Background(), testLogger(), mock, []common.Address{wallet}, nil, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+// TestSweepAll_SkipsEmptyWalletsViaMulticall verifies that SweepAll does not
+// call sweepKey (and thus sends no transactions) for wallets that have zero
+// balances according to the multicall pre-check.
+func TestSweepAll_SkipsEmptyWalletsViaMulticall(t *testing.T) {
+	kp := newTestKey(t)
+
+	var txSent bool
+	mock := fullMock()
+	// multicall returns all zeros
+	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+		if *msg.To == multicall3Address {
+			// One call: ETH balance = 0
+			return encodeAggregate3Response([]*big.Int{big.NewInt(0)}), nil
+		}
+		return make([]byte, 32), nil
+	}
+	mock.sendTransactionFn = func(ctx context.Context, tx *types.Transaction) error {
+		txSent = true
+		return nil
+	}
+
+	sw := NewSweeper(mock, mock, common.Address{}, nil, nil, nil, 0, 0, testLogger())
+	if err := sw.SweepAll(context.Background(), []KeyPair{kp}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if txSent {
+		t.Fatal("expected no transactions for empty wallet")
+	}
+}

--- a/tools/sweeper/multicall_test.go
+++ b/tools/sweeper/multicall_test.go
@@ -25,14 +25,14 @@ import (
 //
 //	32             outer offset (0x20)
 //	32             array length n
-//	n×32           per-element offset table (offsets relative to start of array content)
+//	n×32           per-element offset table (offsets relative to start of offset table)
 //	n × (32+32+32+32)  element bodies: success + bytesRelOff(0x40) + bytesLen(32) + 32-byte value
 func encodeAggregate3Response(vals []*big.Int) []byte {
 	n := len(vals)
 
 	// Each element body is 4×32 = 128 bytes.
 	// Per-element offset table is n×32 bytes.
-	// Element i starts at: n*32 (table) + i*128 (preceding bodies), relative to arrayContent.
+	// Element i starts at: n*32 (table) + i*128 (preceding bodies), relative to offsetTableBase.
 	buf := make([]byte, 0, 32+32+n*32+n*128)
 
 	buf = appendUint256(buf, 0x20) // outer offset

--- a/tools/sweeper/multicall_test.go
+++ b/tools/sweeper/multicall_test.go
@@ -208,6 +208,38 @@ func TestMulticallBalances_Empty(t *testing.T) {
 	}
 }
 
+func TestMulticallBalances_DustFilter(t *testing.T) {
+	wallet := common.HexToAddress("0x1111")
+	minETH := big.NewInt(21000) // dust threshold
+
+	tests := []struct {
+		name      string
+		balance   *big.Int
+		wantFunds bool
+	}{
+		{"below dust", big.NewInt(20999), false},
+		{"at dust", big.NewInt(21000), false},
+		{"above dust", big.NewInt(21001), true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockClient{
+				callContractFn: func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+					return encodeAggregate3Response([]*big.Int{tc.balance}), nil
+				},
+			}
+			results, err := MulticallBalances(context.Background(), testLogger(), mock, []common.Address{wallet}, nil, minETH)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if results[0].HasFunds() != tc.wantFunds {
+				t.Fatalf("HasFunds()=%v, want %v (balance=%s, minETH=%s)", results[0].HasFunds(), tc.wantFunds, tc.balance, minETH)
+			}
+		})
+	}
+}
+
 func TestMulticallBalances_RPCError(t *testing.T) {
 	wallet := common.HexToAddress("0x1111")
 

--- a/tools/sweeper/multicall_test.go
+++ b/tools/sweeper/multicall_test.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package sweeper
 
 import (

--- a/tools/sweeper/multicall_test.go
+++ b/tools/sweeper/multicall_test.go
@@ -57,7 +57,7 @@ func encodeAggregate3Response(vals []*big.Int) []byte {
 
 func TestMulticallBalances_AllZero(t *testing.T) {
 	wallet := common.HexToAddress("0x1111")
-	token := common.HexToAddress("0xtoken")
+	token := common.HexToAddress("0x1111111111111111111111111111111111111111")
 
 	mock := &mockClient{
 		callContractFn: func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
@@ -101,7 +101,7 @@ func TestMulticallBalances_ETHNonZero(t *testing.T) {
 
 func TestMulticallBalances_TokenNonZero(t *testing.T) {
 	wallet := common.HexToAddress("0x1111")
-	token := common.HexToAddress("0xtoken")
+	token := common.HexToAddress("0x1111111111111111111111111111111111111111")
 
 	mock := &mockClient{
 		callContractFn: func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {

--- a/tools/sweeper/multicall_test.go
+++ b/tools/sweeper/multicall_test.go
@@ -14,42 +14,39 @@ import (
 // testing. Each value in vals is encoded as a successful (bool success, bytes
 // returnData) tuple where returnData is the 32-byte big-endian representation
 // of the value.
+//
+// The return type (bool,bytes)[] is an array of dynamic tuples, so it uses the
+// two-level ABI encoding: a per-element offset table followed by the element
+// bodies. This must match what a real Multicall3 contract returns.
+//
+// Layout:
+//
+//	32             outer offset (0x20)
+//	32             array length n
+//	n×32           per-element offset table (offsets relative to start of array content)
+//	n × (32+32+32+32)  element bodies: success + bytesRelOff(0x40) + bytesLen(32) + 32-byte value
 func encodeAggregate3Response(vals []*big.Int) []byte {
 	n := len(vals)
 
-	// Layout (all sizes in bytes):
-	//   32  outer offset (= 0x20)
-	//   32  array length
-	//   n*64  element heads: success(32) + dataOffset(32)
-	//   n*64  element tails: bytesLen(32) + 32-byte payload
+	// Each element body is 4×32 = 128 bytes.
+	// Per-element offset table is n×32 bytes.
+	// Element i starts at: n*32 (table) + i*128 (preceding bodies), relative to arrayContent.
+	buf := make([]byte, 0, 32+32+n*32+n*128)
 
-	// dataOffset for element i is relative to the start of the array content
-	// (i.e., right after the outer-offset and length words).
-	// Array content starts at byte 64 (0x40) from the start of the return data.
-	// Element heads occupy n*64 bytes.
-	// Element i's tail starts at n*64 + i*64 bytes from the start of array content.
-
-	buf := make([]byte, 0, 64+n*128)
-
-	// outer offset
-	buf = appendUint256(buf, 0x20)
-	// array length
+	buf = appendUint256(buf, 0x20) // outer offset
 	buf = appendUint256(buf, uint64(n))
 
-	// heads
+	// Per-element offset table.
 	for i := range n {
-		// success = true
-		buf = appendUint256(buf, 1)
-		// offset to bytes returnData, relative to start of array content (after length word)
-		// = n*64 (all heads) + i*64 (preceding tails)
-		buf = appendUint256(buf, uint64(n*64+i*64))
+		off := uint64(n*32 + i*128)
+		buf = appendUint256(buf, off)
 	}
 
-	// tails
+	// Element bodies.
 	for _, v := range vals {
-		// bytes length = 32
-		buf = appendUint256(buf, 32)
-		// 32-byte value
+		buf = appendUint256(buf, 1)    // success = true
+		buf = appendUint256(buf, 0x40) // offset to returnData bytes, relative to element start (2×32)
+		buf = appendUint256(buf, 32)   // bytes length
 		var word [32]byte
 		v.FillBytes(word[:])
 		buf = append(buf, word[:]...)

--- a/tools/sweeper/sweeper.go
+++ b/tools/sweeper/sweeper.go
@@ -67,6 +67,9 @@ func (s *Sweeper) SweepAll(ctx context.Context, keys []KeyPair) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	if len(keys) == 0 {
+		return nil
+	}
 
 	addrs := make([]common.Address, len(keys))
 	for i, kp := range keys {
@@ -359,9 +362,8 @@ func logBalanceSummary(logger *slog.Logger, network string, balances []WalletBal
 			}
 		}
 	}
-	args := []any{"network", network, "ETH_wallets", ethCount, "ETH_total", ethTotal.String()}
+	logger.Info("balance check complete", "network", network, "ETH_wallets", ethCount, "ETH_total", ethTotal.String())
 	for i, token := range tokens {
-		args = append(args, token.Hex()+"_wallets", tokenCounts[i], token.Hex()+"_total", tokenTotals[i].String())
+		logger.Info("token balance summary", "network", network, "token", token.Hex(), "wallets", tokenCounts[i], "total", tokenTotals[i].String())
 	}
-	logger.Info("balance check complete", args...)
 }

--- a/tools/sweeper/sweeper.go
+++ b/tools/sweeper/sweeper.go
@@ -64,28 +64,51 @@ func NewSweeper(
 // sweep. If maxFailures > 0 and that many wallets fail, the sweep is aborted
 // early (circuit breaker). All failures are logged as a summary at the end.
 func (s *Sweeper) SweepAll(ctx context.Context, keys []KeyPair) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	addrs := make([]common.Address, len(keys))
+	for i, kp := range keys {
+		addrs[i] = kp.Address
+	}
+
+	ethBalances, err := s.queryBalances(ctx, s.ethClient, addrs, s.ethTokens, "ethereum")
+	if err != nil {
+		return err
+	}
+
+	zkBalances, err := s.queryBalances(ctx, s.zkClient, addrs, s.zkTokens, "zksync")
+	if err != nil {
+		return err
+	}
+
 	var failures []SweepFailure
-	for _, kp := range keys {
-		if err := s.sweepKey(ctx, kp, s.ethClient, s.ethTokens, "ethereum"); err != nil {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			s.logger.Error("sweep failed, continuing", "network", "ethereum", "address", kp.Address.Hex(), "keyLine", kp.LineNum, "error", err)
-			failures = append(failures, SweepFailure{Network: "ethereum", Address: kp.Address, LineNum: kp.LineNum, Err: err})
-			if s.maxFailures > 0 && len(failures) >= s.maxFailures {
-				s.logger.Error("circuit breaker tripped, aborting sweep", "failures", len(failures), "max", s.maxFailures)
-				break
+	for i, kp := range keys {
+		if ethBalances[i].HasFunds() {
+			if err := s.sweepKey(ctx, kp, s.ethClient, s.ethTokens, "ethereum"); err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				s.logger.Error("sweep failed, continuing", "network", "ethereum", "address", kp.Address.Hex(), "keyLine", kp.LineNum, "error", err)
+				failures = append(failures, SweepFailure{Network: "ethereum", Address: kp.Address, LineNum: kp.LineNum, Err: err})
+				if s.maxFailures > 0 && len(failures) >= s.maxFailures {
+					s.logger.Error("circuit breaker tripped, aborting sweep", "failures", len(failures), "max", s.maxFailures)
+					break
+				}
 			}
 		}
-		if err := s.sweepKey(ctx, kp, s.zkClient, s.zkTokens, "zksync"); err != nil {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			s.logger.Error("sweep failed, continuing", "network", "zksync", "address", kp.Address.Hex(), "keyLine", kp.LineNum, "error", err)
-			failures = append(failures, SweepFailure{Network: "zksync", Address: kp.Address, LineNum: kp.LineNum, Err: err})
-			if s.maxFailures > 0 && len(failures) >= s.maxFailures {
-				s.logger.Error("circuit breaker tripped, aborting sweep", "failures", len(failures), "max", s.maxFailures)
-				break
+		if zkBalances[i].HasFunds() {
+			if err := s.sweepKey(ctx, kp, s.zkClient, s.zkTokens, "zksync"); err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				s.logger.Error("sweep failed, continuing", "network", "zksync", "address", kp.Address.Hex(), "keyLine", kp.LineNum, "error", err)
+				failures = append(failures, SweepFailure{Network: "zksync", Address: kp.Address, LineNum: kp.LineNum, Err: err})
+				if s.maxFailures > 0 && len(failures) >= s.maxFailures {
+					s.logger.Error("circuit breaker tripped, aborting sweep", "failures", len(failures), "max", s.maxFailures)
+					break
+				}
 			}
 		}
 	}
@@ -298,4 +321,47 @@ func (s *Sweeper) sendETHTransfer(ctx context.Context, client BlockchainClient, 
 	}
 
 	return nil
+}
+
+func (s *Sweeper) queryBalances(ctx context.Context, client BlockchainClient, addrs []common.Address, tokens []common.Address, network string) ([]WalletBalances, error) {
+	gasPrice, err := client.SuggestGasPrice(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%s gas price: %w", network, err)
+	}
+	minETH := new(big.Int).Mul(gasPrice, big.NewInt(21000))
+
+	s.logger.Info("querying balances via multicall", "network", network, "wallets", len(addrs))
+	balances, err := MulticallBalances(ctx, s.logger, client, addrs, tokens, minETH)
+	if err != nil {
+		return nil, fmt.Errorf("multicall %s balances: %w", network, err)
+	}
+	logBalanceSummary(s.logger, network, balances, tokens)
+	return balances, nil
+}
+
+func logBalanceSummary(logger *slog.Logger, network string, balances []WalletBalances, tokens []common.Address) {
+	ethCount := 0
+	ethTotal := new(big.Int)
+	tokenCounts := make([]int, len(tokens))
+	tokenTotals := make([]*big.Int, len(tokens))
+	for i := range tokens {
+		tokenTotals[i] = new(big.Int)
+	}
+	for _, wb := range balances {
+		if wb.ETH.Sign() > 0 {
+			ethCount++
+			ethTotal.Add(ethTotal, wb.ETH)
+		}
+		for i, t := range wb.Tokens {
+			if t.Sign() > 0 {
+				tokenCounts[i]++
+				tokenTotals[i].Add(tokenTotals[i], t)
+			}
+		}
+	}
+	args := []any{"network", network, "ETH_wallets", ethCount, "ETH_total", ethTotal.String()}
+	for i, token := range tokens {
+		args = append(args, token.Hex()+"_wallets", tokenCounts[i], token.Hex()+"_total", tokenTotals[i].String())
+	}
+	logger.Info("balance check complete", args...)
 }

--- a/tools/sweeper/sweeper.go
+++ b/tools/sweeper/sweeper.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package sweeper
 
 import (

--- a/tools/sweeper/sweeper_test.go
+++ b/tools/sweeper/sweeper_test.go
@@ -1,3 +1,5 @@
+// Copyright (C) 2026 Storj Labs, Inc.
+// See LICENSE for copying information.
 package sweeper
 
 import (

--- a/tools/sweeper/sweeper_test.go
+++ b/tools/sweeper/sweeper_test.go
@@ -28,9 +28,46 @@ func successReceipt() *types.Receipt {
 	return &types.Receipt{Status: types.ReceiptStatusSuccessful}
 }
 
+// multicallZeroResponse returns a valid aggregate3 response with n zero-value results.
+func multicallZeroResponse(n int) []byte {
+	vals := make([]*big.Int, n)
+	for i := range vals {
+		vals[i] = big.NewInt(0)
+	}
+	return encodeAggregate3Response(vals)
+}
+
+// multicallValueResponse returns a valid aggregate3 response where every result
+// is set to the given value.
+func multicallValueResponse(n int, val *big.Int) []byte {
+	vals := make([]*big.Int, n)
+	for i := range vals {
+		vals[i] = new(big.Int).Set(val)
+	}
+	return encodeAggregate3Response(vals)
+}
+
+// mockCallContract returns a callContractFn that routes Multicall3 aggregate3
+// calls to the provided multicallFn and all other calls to erc20Fn.
+func mockCallContract(
+	multicallFn func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error),
+	erc20Fn func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error),
+) func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	return func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+		if msg.To != nil && *msg.To == multicall3Address {
+			return multicallFn(ctx, msg, blockNumber)
+		}
+		return erc20Fn(ctx, msg, blockNumber)
+	}
+}
+
 // fullMock returns a mockClient with reasonable defaults for sweep tests.
+// The callContractFn automatically handles Multicall3 aggregate3 calls by
+// forwarding ETH-balance sub-calls to the mock's own balanceAtFn, so that
+// tests only need to set balanceAtFn to control what the multicall pre-check
+// sees.
 func fullMock() *mockClient {
-	return &mockClient{
+	m := &mockClient{
 		balanceAtFn: func(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
 			return big.NewInt(0), nil
 		},
@@ -49,13 +86,38 @@ func fullMock() *mockClient {
 		chainIDFn: func(ctx context.Context) (*big.Int, error) {
 			return big.NewInt(1), nil
 		},
-		callContractFn: func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-			return make([]byte, 32), nil // zero balance
-		},
 		transactionReceiptFn: func(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 			return successReceipt(), nil
 		},
 	}
+	// callContractFn is set after m is created so it can close over m to
+	// delegate ETH-balance queries within a multicall to balanceAtFn.
+	m.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+		if msg.To != nil && *msg.To == multicall3Address {
+			n := multicallCallCount(msg.Data)
+			// Use the first wallet's ETH balance as representative for all slots.
+			// Most tests use a single wallet; for multi-wallet tests the specific
+			// balance per address doesn't matter as long as it's consistent.
+			bal, err := m.balanceAtFn(ctx, common.Address{}, nil)
+			if err != nil {
+				// If balanceAtFn errors, return zero so sweepKey is not called
+				// and the error surfaces there instead.
+				return multicallZeroResponse(n), nil
+			}
+			return multicallValueResponse(n, bal), nil
+		}
+		return make([]byte, 32), nil // zero ERC20 balance
+	}
+	return m
+}
+
+// multicallCallCount extracts the number of sub-calls from aggregate3 calldata.
+// Layout: 4-byte selector + 32-byte outer offset + 32-byte array length + ...
+func multicallCallCount(data []byte) int {
+	if len(data) < 4+32+32 {
+		return 0
+	}
+	return int(new(big.Int).SetBytes(data[4+32 : 4+32+32]).Uint64())
 }
 
 func TestSweepAll_AllZeroBalances(t *testing.T) {
@@ -124,11 +186,17 @@ func TestSweepAll_ERC20Only(t *testing.T) {
 	mock.suggestGasPriceFn = func(ctx context.Context) (*big.Int, error) {
 		return gasPrice, nil
 	}
-	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-		result := make([]byte, 32)
-		tokenBalance.FillBytes(result)
-		return result, nil
-	}
+	mock.callContractFn = mockCallContract(
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, tokenBalance), nil
+		},
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			result := make([]byte, 32)
+			tokenBalance.FillBytes(result)
+			return result, nil
+		},
+	)
 	mock.sendTransactionFn = func(ctx context.Context, tx *types.Transaction) error {
 		if *tx.To() == token {
 			erc20TxSent = true
@@ -163,11 +231,17 @@ func TestSweepAll_MixedSweep(t *testing.T) {
 	mock.suggestGasPriceFn = func(ctx context.Context) (*big.Int, error) {
 		return gasPrice, nil
 	}
-	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-		result := make([]byte, 32)
-		tokenBalance.FillBytes(result)
-		return result, nil
-	}
+	mock.callContractFn = mockCallContract(
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, tokenBalance), nil
+		},
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			result := make([]byte, 32)
+			tokenBalance.FillBytes(result)
+			return result, nil
+		},
+	)
 	mock.sendTransactionFn = func(ctx context.Context, tx *types.Transaction) error {
 		if *tx.To() == token {
 			erc20Sent = true
@@ -220,11 +294,17 @@ func TestSweepAll_GasFunding(t *testing.T) {
 	mock.suggestGasPriceFn = func(ctx context.Context) (*big.Int, error) {
 		return gasPrice, nil
 	}
-	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-		result := make([]byte, 32)
-		big.NewInt(100).FillBytes(result)
-		return result, nil
-	}
+	mock.callContractFn = mockCallContract(
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, big.NewInt(100)), nil
+		},
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			result := make([]byte, 32)
+			big.NewInt(100).FillBytes(result)
+			return result, nil
+		},
+	)
 	mock.sendTransactionFn = func(ctx context.Context, tx *types.Transaction) error {
 		if tx.To() != nil && *tx.To() == kp.Address {
 			funded = true
@@ -256,11 +336,17 @@ func TestSweepAll_NoGasSource(t *testing.T) {
 	mock.suggestGasPriceFn = func(ctx context.Context) (*big.Int, error) {
 		return gasPrice, nil
 	}
-	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-		result := make([]byte, 32)
-		big.NewInt(100).FillBytes(result)
-		return result, nil
-	}
+	mock.callContractFn = mockCallContract(
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, big.NewInt(100)), nil
+		},
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			result := make([]byte, 32)
+			big.NewInt(100).FillBytes(result)
+			return result, nil
+		},
+	)
 
 	// Without gas source, it will still try to send the ERC20 transfer
 	// (it doesn't check if there's enough gas — the tx will likely fail on-chain)
@@ -355,7 +441,16 @@ func TestSweepAll_ContextCanceled(t *testing.T) {
 
 func TestSweepAll_BalanceError(t *testing.T) {
 	kp := newTestKey(t)
+	ethBalance := big.NewInt(1000000000000000000)
 	mock := fullMock()
+	// Multicall reports ETH balance so sweepKey is entered, then balanceAtFn fails.
+	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+		if msg.To != nil && *msg.To == multicall3Address {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, ethBalance), nil
+		}
+		return make([]byte, 32), nil
+	}
 	mock.balanceAtFn = func(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
 		return nil, errors.New("rpc error")
 	}
@@ -373,6 +468,7 @@ func TestSweepAll_ERC20BalanceError(t *testing.T) {
 	mock.balanceAtFn = func(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
 		return big.NewInt(1000000000000000000), nil
 	}
+	// Multicall itself fails — this should surface as an error from SweepAll.
 	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
 		return nil, errors.New("call error")
 	}
@@ -450,11 +546,17 @@ func TestSweepAll_GasEstimateError(t *testing.T) {
 	mock.balanceAtFn = func(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
 		return big.NewInt(1000000000000000000), nil
 	}
-	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-		result := make([]byte, 32)
-		big.NewInt(100).FillBytes(result)
-		return result, nil
-	}
+	mock.callContractFn = mockCallContract(
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, big.NewInt(100)), nil
+		},
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			result := make([]byte, 32)
+			big.NewInt(100).FillBytes(result)
+			return result, nil
+		},
+	)
 	mock.suggestGasPriceFn = func(ctx context.Context) (*big.Int, error) {
 		return nil, errors.New("gas price error")
 	}
@@ -478,11 +580,17 @@ func TestSweepAll_ERC20SendError(t *testing.T) {
 	mock.suggestGasPriceFn = func(ctx context.Context) (*big.Int, error) {
 		return gasPrice, nil
 	}
-	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-		result := make([]byte, 32)
-		big.NewInt(100).FillBytes(result)
-		return result, nil
-	}
+	mock.callContractFn = mockCallContract(
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, big.NewInt(100)), nil
+		},
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			result := make([]byte, 32)
+			big.NewInt(100).FillBytes(result)
+			return result, nil
+		},
+	)
 	mock.sendTransactionFn = func(ctx context.Context, tx *types.Transaction) error {
 		if tx.To() != nil && *tx.To() == token {
 			return errors.New("send error")
@@ -509,11 +617,17 @@ func TestSweepAll_ERC20ChainIDError(t *testing.T) {
 	mock.suggestGasPriceFn = func(ctx context.Context) (*big.Int, error) {
 		return gasPrice, nil
 	}
-	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-		result := make([]byte, 32)
-		big.NewInt(100).FillBytes(result)
-		return result, nil
-	}
+	mock.callContractFn = mockCallContract(
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, big.NewInt(100)), nil
+		},
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			result := make([]byte, 32)
+			big.NewInt(100).FillBytes(result)
+			return result, nil
+		},
+	)
 	mock.chainIDFn = func(ctx context.Context) (*big.Int, error) {
 		return nil, errors.New("chain ID error")
 	}
@@ -537,11 +651,17 @@ func TestSweepAll_ERC20NonceError(t *testing.T) {
 	mock.suggestGasPriceFn = func(ctx context.Context) (*big.Int, error) {
 		return gasPrice, nil
 	}
-	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-		result := make([]byte, 32)
-		big.NewInt(100).FillBytes(result)
-		return result, nil
-	}
+	mock.callContractFn = mockCallContract(
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, big.NewInt(100)), nil
+		},
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			result := make([]byte, 32)
+			big.NewInt(100).FillBytes(result)
+			return result, nil
+		},
+	)
 	mock.pendingNonceAtFn = func(ctx context.Context, account common.Address) (uint64, error) {
 		return 0, errors.New("nonce error")
 	}
@@ -562,11 +682,17 @@ func TestSweepAll_ERC20GasPriceError(t *testing.T) {
 	mock.balanceAtFn = func(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
 		return big.NewInt(1000000000000000000), nil
 	}
-	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-		result := make([]byte, 32)
-		big.NewInt(100).FillBytes(result)
-		return result, nil
-	}
+	mock.callContractFn = mockCallContract(
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, big.NewInt(100)), nil
+		},
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			result := make([]byte, 32)
+			big.NewInt(100).FillBytes(result)
+			return result, nil
+		},
+	)
 	mock.suggestGasPriceFn = func(ctx context.Context) (*big.Int, error) {
 		callCount++
 		if callCount <= 1 {
@@ -595,11 +721,17 @@ func TestSweepAll_ERC20EstimateGasError(t *testing.T) {
 	mock.suggestGasPriceFn = func(ctx context.Context) (*big.Int, error) {
 		return gasPrice, nil
 	}
-	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-		result := make([]byte, 32)
-		big.NewInt(100).FillBytes(result)
-		return result, nil
-	}
+	mock.callContractFn = mockCallContract(
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, big.NewInt(100)), nil
+		},
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			result := make([]byte, 32)
+			big.NewInt(100).FillBytes(result)
+			return result, nil
+		},
+	)
 	mock.estimateGasFn = func(ctx context.Context, msg ethereum.CallMsg) (uint64, error) {
 		callCount++
 		if callCount <= 1 {
@@ -627,11 +759,17 @@ func TestSweepAll_ERC20ReceiptError(t *testing.T) {
 	mock.suggestGasPriceFn = func(ctx context.Context) (*big.Int, error) {
 		return gasPrice, nil
 	}
-	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-		result := make([]byte, 32)
-		big.NewInt(100).FillBytes(result)
-		return result, nil
-	}
+	mock.callContractFn = mockCallContract(
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, big.NewInt(100)), nil
+		},
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			result := make([]byte, 32)
+			big.NewInt(100).FillBytes(result)
+			return result, nil
+		},
+	)
 	mock.transactionReceiptFn = func(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 		return nil, errors.New("receipt error")
 	}
@@ -655,11 +793,17 @@ func TestSweepAll_ERC20FailedReceipt(t *testing.T) {
 	mock.suggestGasPriceFn = func(ctx context.Context) (*big.Int, error) {
 		return gasPrice, nil
 	}
-	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
-		result := make([]byte, 32)
-		big.NewInt(100).FillBytes(result)
-		return result, nil
-	}
+	mock.callContractFn = mockCallContract(
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, big.NewInt(100)), nil
+		},
+		func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+			result := make([]byte, 32)
+			big.NewInt(100).FillBytes(result)
+			return result, nil
+		},
+	)
 	mock.transactionReceiptFn = func(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 		return &types.Receipt{Status: types.ReceiptStatusFailed}, nil
 	}
@@ -821,9 +965,17 @@ func TestSweepAll_ContinuesPastFailures(t *testing.T) {
 	destination := common.HexToAddress("0xdead")
 	ethBalance := big.NewInt(1000000000000000000)
 
-	// kp1 fails balance check, kp2 succeeds and gets swept.
+	// Both wallets have ETH (multicall returns non-zero so sweepKey is called).
+	// kp1 fails the balance re-check inside sweepKey; kp2 succeeds.
 	var kp2Swept bool
 	mock := fullMock()
+	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+		if msg.To != nil && *msg.To == multicall3Address {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, ethBalance), nil
+		}
+		return make([]byte, 32), nil
+	}
 	mock.balanceAtFn = func(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
 		if account == kp1.Address {
 			return nil, errors.New("rpc error")
@@ -859,43 +1011,52 @@ func TestSweepAll_CircuitBreaker(t *testing.T) {
 	kp3 := newTestKey(t)
 	kp3.LineNum = 3
 
-	// All wallets fail balance check.
+	ethBalance := big.NewInt(1000000000000000000)
+
+	// All wallets have ETH (multicall returns non-zero) but fail inside sweepKey.
+	sweepCalls := 0
 	mock := fullMock()
+	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+		if msg.To != nil && *msg.To == multicall3Address {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, ethBalance), nil
+		}
+		return make([]byte, 32), nil
+	}
 	mock.balanceAtFn = func(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
+		sweepCalls++
 		return nil, errors.New("rpc error")
 	}
 
-	balanceCalls := 0
-	mock.balanceAtFn = func(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
-		balanceCalls++
-		return nil, errors.New("rpc error")
-	}
-
-	// Circuit breaker at 2 failures — should stop before processing kp3.
+	// Circuit breaker at 2 failures — should stop before processing kp2/kp3.
+	// With maxFailures=2: kp1 eth fails (1), kp1 zksync fails (2) → trips.
 	sw := NewSweeper(mock, mock, common.Address{}, nil, nil, nil, 0, 2, slog.New(slog.DiscardHandler))
 	err := sw.SweepAll(context.Background(), []KeyPair{kp1, kp2, kp3})
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	// With maxFailures=2: kp1 eth fails (1), kp1 zksync fails (2) → trips.
-	// kp2 and kp3 should not be attempted.
-	if balanceCalls != 2 {
-		t.Fatalf("expected 2 balance calls (circuit breaker at 2), got %d", balanceCalls)
+	if sweepCalls != 2 {
+		t.Fatalf("expected 2 sweepKey calls (circuit breaker at 2), got %d", sweepCalls)
 	}
 }
 
 func TestSweepAll_CircuitBreakerMidKey(t *testing.T) {
 	kp1 := newTestKey(t)
 
-	mock := fullMock()
-	mock.balanceAtFn = func(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
-		return nil, errors.New("rpc error")
-	}
+	ethBalance := big.NewInt(1000000000000000000)
 
-	// maxFailures=1: ethereum fails → trips immediately, zksync not attempted.
-	balanceCalls := 0
+	// maxFailures=1: ethereum sweepKey fails → trips immediately, zksync not attempted.
+	sweepCalls := 0
+	mock := fullMock()
+	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+		if msg.To != nil && *msg.To == multicall3Address {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, ethBalance), nil
+		}
+		return make([]byte, 32), nil
+	}
 	mock.balanceAtFn = func(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
-		balanceCalls++
+		sweepCalls++
 		return nil, errors.New("rpc error")
 	}
 
@@ -904,8 +1065,8 @@ func TestSweepAll_CircuitBreakerMidKey(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	if balanceCalls != 1 {
-		t.Fatalf("expected 1 balance call (circuit breaker at 1), got %d", balanceCalls)
+	if sweepCalls != 1 {
+		t.Fatalf("expected 1 sweepKey call (circuit breaker at 1), got %d", sweepCalls)
 	}
 }
 
@@ -913,7 +1074,15 @@ func TestSweepAll_FailureIncludesLineNum(t *testing.T) {
 	kp := newTestKey(t)
 	kp.LineNum = 42
 
+	ethBalance := big.NewInt(1000000000000000000)
 	mock := fullMock()
+	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+		if msg.To != nil && *msg.To == multicall3Address {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, ethBalance), nil
+		}
+		return make([]byte, 32), nil
+	}
 	mock.balanceAtFn = func(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
 		return nil, errors.New("rpc error")
 	}
@@ -933,10 +1102,18 @@ func TestSweepAll_UnlimitedFailures(t *testing.T) {
 		keys[i].LineNum = i + 1
 	}
 
-	balanceCalls := 0
+	ethBalance := big.NewInt(1000000000000000000)
+	sweepCalls := 0
 	mock := fullMock()
+	mock.callContractFn = func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+		if msg.To != nil && *msg.To == multicall3Address {
+			n := multicallCallCount(msg.Data)
+			return multicallValueResponse(n, ethBalance), nil
+		}
+		return make([]byte, 32), nil
+	}
 	mock.balanceAtFn = func(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error) {
-		balanceCalls++
+		sweepCalls++
 		return nil, errors.New("rpc error")
 	}
 
@@ -945,8 +1122,8 @@ func TestSweepAll_UnlimitedFailures(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error")
 	}
-	// Each key tried on both networks = 20 balance calls.
-	if balanceCalls != 20 {
-		t.Fatalf("expected 20 balance calls (all keys, both networks), got %d", balanceCalls)
+	// Each key has ETH (per multicall) and is attempted on both networks = 20 sweepKey calls.
+	if sweepCalls != 20 {
+		t.Fatalf("expected 20 sweepKey calls (all keys, both networks), got %d", sweepCalls)
 	}
 }

--- a/tools/sweeper/sweeper_test.go
+++ b/tools/sweeper/sweeper_test.go
@@ -100,8 +100,8 @@ func fullMock() *mockClient {
 			// balance per address doesn't matter as long as it's consistent.
 			bal, err := m.balanceAtFn(ctx, common.Address{}, nil)
 			if err != nil {
-				// If balanceAtFn errors, return zero so sweepKey is not called
-				// and the error surfaces there instead.
+				// If balanceAtFn errors, return zero so the wallet is skipped by
+				// the multicall pre-filter (HasFunds=false).
 				return multicallZeroResponse(n), nil
 			}
 			return multicallValueResponse(n, bal), nil


### PR DESCRIPTION
Replace per-wallet individual RPC calls for balance checking with batched Multicall3 aggregate3 calls. For 66,000 wallets this reduces the balance-check phase from ~132,000 serialized RPC calls (around a day with rate limiting) to a few hundred batched eth_calls (executed in minutes).

Changes:
- Add multicall.go with hand-rolled ABI encoding/decoding for Multicall3 aggregate3, batching up to 500 calls per request
- SweepAll now runs a multicall pre-filter on both networks before the sweep loop, skipping wallets with no funds
- Gas price is fetched once per network before the multicall; ETH balances at or below the cost of a plain transfer (gasPrice × 21000) are treated as dust and filtered out, avoiding sweepKey calls for wallets with only unrecoverable ETH breadcrumbs
- Add balance summary log after each network's multicall showing wallet counts and total amounts per asset